### PR TITLE
native mic recording

### DIFF
--- a/XcodeLibraryProject/iVidCapPro/GPUImageMovieWriter.m
+++ b/XcodeLibraryProject/iVidCapPro/GPUImageMovieWriter.m
@@ -61,8 +61,6 @@ NSString *const kGPUImageMovieGammaFragmentShaderString = SHADER_STRING
 
     GLuint inputTextureForMovieRendering;
     
-    GLubyte *frameData;
-    
     CMTime startTime, previousFrameTime;
     
     BOOL isRecording;
@@ -195,11 +193,6 @@ NSString *const kGPUImageMovieGammaFragmentShaderString = SHADER_STRING
 - (void)dealloc;
 {
     [self destroyDataFBO];
-
-    if (frameData != NULL)
-    {
-        free(frameData);
-    }
 }
 
 #pragma mark -
@@ -210,9 +203,7 @@ NSString *const kGPUImageMovieGammaFragmentShaderString = SHADER_STRING
     isRecording = NO;
     
     self.enabled = YES;
-    frameData = (GLubyte *) malloc((int)videoSize.width * (int)videoSize.height * 4);
 
-//    frameData = (GLubyte *) calloc(videoSize.width * videoSize.height * 4, sizeof(GLubyte));
     NSError *error = nil;
     assetWriter = [[AVAssetWriter alloc] initWithURL:movieURL fileType:fileType error:&error];
     if (error != nil)

--- a/XcodeLibraryProject/iVidCapPro/iVidCap.h
+++ b/XcodeLibraryProject/iVidCapPro/iVidCap.h
@@ -46,7 +46,8 @@ static int Demo_FrameLimit = 10 * 30;               // set later based on actual
 enum AudioCapture {
     No_Audio = 0,
     Audio = 1,
-    Audio_Plus_Mic = 2
+    Audio_Plus_Mic = 2,
+    Audio_Mic = 3
 };
 
 // This enum must be kept in sync with the VideoDisposition enum in iVidCap.cs.
@@ -75,7 +76,7 @@ enum VideoCaptureFramerateLock {
     Throttled = 2
 };
 
-@interface ivcp_VideoRecorder : NSObject {
+@interface ivcp_VideoRecorder : NSObject <AVAudioRecorderDelegate> {
 
     
     // Video attributes.
@@ -123,6 +124,9 @@ enum VideoCaptureFramerateLock {
     AVAsset* userAudioAsset1;
     AVAsset* userAudioAsset2;
     AVAsset* mixedAudioAsset;
+    
+    // Mic audio recording.
+    AVAudioRecorder * micAudioRecorder;
     
     // Debug.
     BOOL showDebug;

--- a/XcodeLibraryProject/iVidCapPro/iVidCap.h
+++ b/XcodeLibraryProject/iVidCapPro/iVidCap.h
@@ -127,6 +127,8 @@ enum VideoCaptureFramerateLock {
     
     // Mic audio recording.
     AVAudioRecorder * micAudioRecorder;
+    BOOL bMicAudioRecordFinished;
+    BOOL bMovieWriterFinished;
     
     // Debug.
     BOOL showDebug;

--- a/XcodeLibraryProject/iVidCapPro/iVidCap.mm
+++ b/XcodeLibraryProject/iVidCapPro/iVidCap.mm
@@ -310,6 +310,8 @@ static SessionStatusCode vr_sessionStatus;
         finalVideoFileName = nil;
     }
     
+    [self micAudioRecorderKill];
+    
     strcpy(iVidCapGameObject, "");
 
 	[super dealloc];
@@ -587,11 +589,17 @@ static SessionStatusCode vr_sessionStatus;
     glFinish();
     [EAGLContext setCurrentContext: unity_context];
     
+    if(captureAudio == Audio_Mic) {
+        [self micAudioRecorderStart];
+        bMicAudioRecordFinished = NO;
+    }
+    
     // Set the video recording start time.
     recordStartTime = [[NSDate alloc] init];
     [recordStartTime retain];
     
     isRecording = true;
+    bMovieWriterFinished = NO;
     
     if (showDebug)
         NSLog(@"iVidCapPro - beginRecordingSession exiting.");
@@ -625,9 +633,29 @@ static SessionStatusCode vr_sessionStatus;
     // When the movie writer is finished, we'll continue completing the recording
     // session.
     [movieWriter finishRecordingWithCompletionHandler:^{
-        [self movieWriterCompleteHandler];}];
+        bMovieWriterFinished = YES;
+        [self checkAllRecordingsAreFinished];
+    }];
+    
+    if(captureAudio == Audio_Mic) {
+        [self micAudioRecorderStop];
+    }
     
     return 0;
+}
+
+- (void)checkAllRecordingsAreFinished {
+
+    BOOL bFinaliseVideo = YES;
+    bFinaliseVideo = bFinaliseVideo && bMovieWriterFinished;
+    if(captureAudio == Audio_Mic) {
+        bFinaliseVideo = bFinaliseVideo && bMicAudioRecordFinished;
+    }
+    if(bFinaliseVideo == NO) {
+        return; // still waiting on either the video or audio to finish before they can be mixed together.
+    }
+
+    [self movieWriterCompleteHandler];
 }
 
 // This is the continuation of endRecordingSession.
@@ -655,7 +683,7 @@ static SessionStatusCode vr_sessionStatus;
         if (showDebug) {
             NSLog(@"iVidCapPro - endRecordingSession tempVideoFileName=%@\n", tempVideoFileName);
             NSLog(@"iVidCapPro - endRecordingSession finalVideoFileName=%@\n", finalVideoFileName);
-            if (captureAudio == Audio || captureAudio == Audio_Plus_Mic)
+            if (captureAudio == Audio || captureAudio == Audio_Plus_Mic || captureAudio == Audio_Mic)
                 NSLog(@"iVidCapPro - endRecordingSession capturedAudioFileName=%@\n", capturedAudioFileName);
             else
                 NSLog(@"iVidCapPro - endRecordingSession capturedAudioFileName=not in use\n");
@@ -669,7 +697,7 @@ static SessionStatusCode vr_sessionStatus;
                 NSLog(@"iVidCapPro - endRecordingSession userAudioFileName2=not in use\n");
         }
         
-        if (captureAudio == Audio || captureAudio == Audio_Plus_Mic || userAudioFile1 != nil || userAudioFile2 != nil) {
+        if (captureAudio == Audio || captureAudio == Audio_Plus_Mic || captureAudio == Audio_Mic || userAudioFile1 != nil || userAudioFile2 != nil) {
             // We have audio.  Mix the audio and video.
             [self createVideoWithAudio];
             
@@ -711,7 +739,7 @@ static SessionStatusCode vr_sessionStatus;
     NSURL* userAudioFileURL2 = nil;
     NSURL* capturedAudioFileURL = nil;
     
-    if (captureAudio == Audio || captureAudio == Audio_Plus_Mic) {
+    if (captureAudio == Audio || captureAudio == Audio_Plus_Mic || captureAudio == Audio_Mic) {
         // We're capturing audio from scene.  Get the URL for the file.
         capturedAudioFileURL = [self getDocumentsFileURL:capturedAudioFileName];
     }
@@ -1322,11 +1350,25 @@ static SessionStatusCode vr_sessionStatus;
         NSLog(@"iVidCapPro - exportDidFinish: exiting.");
 }
 
+- (void)micAudioRecorderKill {
+    if(micAudioRecorder == nil) {
+        return;
+    }
+    [micAudioRecorder stop];
+    [micAudioRecorder setDelegate:nil];
+    [micAudioRecorder release];
+    micAudioRecorder = nil;
+}
+
 - (void)micAudioRecorderStart {
+    [self micAudioRecorderKill];
+
     NSError * error = nil;
 
     AVAudioSession * audioSession = [AVAudioSession sharedInstance];
-    [audioSession setCategory :AVAudioSessionCategoryPlayAndRecord error:&error];
+    [audioSession setCategory: AVAudioSessionCategoryPlayAndRecord
+                  withOptions: AVAudioSessionCategoryOptionDefaultToSpeaker
+                        error: &error];
     if(error){
         NSLog(@"audioSession: %@ %li %@", [error domain], [error code], [[error userInfo] description]);
         return;
@@ -1363,7 +1405,8 @@ static SessionStatusCode vr_sessionStatus;
 - (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder
                            successfully:(BOOL)flag {
     
-    NSLog (@"audioRecorderDidFinishRecording:successfully:");
+    bMicAudioRecordFinished = YES;
+    [self checkAllRecordingsAreFinished];
 }
 
 @end

--- a/XcodeLibraryProject/iVidCapPro/iVidCap.mm
+++ b/XcodeLibraryProject/iVidCapPro/iVidCap.mm
@@ -1322,6 +1322,50 @@ static SessionStatusCode vr_sessionStatus;
         NSLog(@"iVidCapPro - exportDidFinish: exiting.");
 }
 
+- (void)micAudioRecorderStart {
+    NSError * error = nil;
+
+    AVAudioSession * audioSession = [AVAudioSession sharedInstance];
+    [audioSession setCategory :AVAudioSessionCategoryPlayAndRecord error:&error];
+    if(error){
+        NSLog(@"audioSession: %@ %li %@", [error domain], [error code], [[error userInfo] description]);
+        return;
+    }
+    [audioSession setActive:YES error:&error];
+    if(error){
+        NSLog(@"audioSession: %@ %li %@", [error domain], [error code], [[error userInfo] description]);
+        return;
+    }
+    
+    NSMutableDictionary * recordSetting = [NSMutableDictionary dictionary];
+    [recordSetting setValue :[NSNumber numberWithInt:kAudioFormatLinearPCM] forKey:AVFormatIDKey];
+    [recordSetting setValue:[NSNumber numberWithFloat:44100.0] forKey:AVSampleRateKey];
+    [recordSetting setValue:[NSNumber numberWithInt: 2] forKey:AVNumberOfChannelsKey];
+    [recordSetting setValue :[NSNumber numberWithInt:16] forKey:AVLinearPCMBitDepthKey];
+    [recordSetting setValue :[NSNumber numberWithBool:NO] forKey:AVLinearPCMIsBigEndianKey];
+    [recordSetting setValue :[NSNumber numberWithBool:NO] forKey:AVLinearPCMIsFloatKey];
+    
+    NSURL * url = [self getDocumentsFileURL:capturedAudioFileName];
+    micAudioRecorder = [[ AVAudioRecorder alloc] initWithURL:url settings:recordSetting error:&error];
+    if(error){
+        NSLog(@"micAudioRecorder: %@ %li %@", [error domain], [error code], [[error userInfo] description]);
+        return;
+    }
+    
+    [micAudioRecorder setDelegate:self];
+    [micAudioRecorder record];
+}
+
+- (void)micAudioRecorderStop {
+    [micAudioRecorder stop];
+}
+
+- (void)audioRecorderDidFinishRecording:(AVAudioRecorder *)recorder
+                           successfully:(BOOL)flag {
+    
+    NSLog (@"audioRecorderDidFinishRecording:successfully:");
+}
+
 @end
 
 

--- a/iVidCapProUnityProject/Assets/Plugins/iVidCapPro/iVidCapPro.cs
+++ b/iVidCapProUnityProject/Assets/Plugins/iVidCapPro/iVidCapPro.cs
@@ -495,7 +495,13 @@ public class iVidCapPro : MonoBehaviour {
 		/// <summary>
 		/// Audio from the scene and microphone will be recorded in addition to video.
 		/// </summary>
-		Audio_Plus_Mic = 2
+		Audio_Plus_Mic = 2,
+
+
+		/// <summary>
+		/// Audio from the microphone only will be recorded in addition to video.
+		/// </summary>
+		Audio_Mic = 3
 	}
 	
 	/// <summary>


### PR DESCRIPTION
here is a way that ive gone about recoding mic input on the iOS end of iVidCapPro.
inside unity, this option is `AudioCapture.Audio_Mic`

i think this gets around the echo that some people were complaining about.
it records mic input, as well as what the phone outputs through the speakers.

in my case, im using this feature for recording AR animations which have sound,
and also capturing what people are saying when viewing the AR animations on their phone.
basically so people can share these videos on their socials.